### PR TITLE
bugfix: issue 13318 #modxbughunt

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -101,7 +101,7 @@ input::-moz-focus-inner {
       opacity: 0;
       filter: alpha(opacity=0); /* for IE <= 8 */
       padding: 17px 8px 0 0;
-      position: absolute; top: 0; left: -8px;
+      position: relative; top: 0; right: 0px;
       transition: all 0.25s;
       width: 16px;
 
@@ -112,7 +112,8 @@ input::-moz-focus-inner {
         color: $coreFieldLabelColor;
         content: $fa-var-refresh;
         font-size: 16px;
-        position: absolute; bottom: 0; left: 0;
+        position: relative; bottom: 0; left: 0;
+        padding-left: 4px;
         text-align: center;
         vertical-align: middle;
         width: 16px; height: 16px;
@@ -134,7 +135,7 @@ input::-moz-focus-inner {
   } /* label.x-form-item-label */
 
   &.modx-tv {
-    padding: 0 0 0 15px !important; /* account for the tv reset icon */
+    padding: 0 0 0 0px !important;
   }
 
   /* is outside of the label */
@@ -394,15 +395,11 @@ input::-moz-focus-inner {
 }
 
 /* issue #5505 */
-.x-form-text, .x-form-display-field {
+.x-form-text {
   /*box-sizing: border-box;*/ /* we cannot use this because extjs calculates widths with the old box-model */
   line-height: 20px;
   min-height: 20px; /* + 5px + 5px padding = 30px */
   padding: 5px;
-}
-.x-form-display-field {
-  border: 1px solid transparent;
-  border-radius: $borderRadius;
 }
 
 .x-form-textarea {


### PR DESCRIPTION
Fixes positioning of tvs on the first tab and moves the resetTV link to the right side of the tv label.

### What does it do?
Remove padding left on tv formfields and move the resettv link to the right side of the tv label.

The details are described here: https://github.com/modxcms/revolution/issues/13318

### Why is it needed?
TVs moved to the first tab have a padding left thats not in line with other form fields. The padding was necessary so the reset TV link could be positioned to the left. Moving the link to the right side of the label and setting padding-left of the formfield to 0 solves the problem.  

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13318