### PR TITLE
Issue 13323, #modxbughunt

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -137,6 +137,25 @@ input::-moz-focus-inner {
   &.modx-tv {
     padding: 0 0 0 0px !important;
   }
+        
+div#modx-resource-main-columns {
+         .modx-tv textarea {
+                box-sizing: border-box;
+                width: 100%!important;
+                min-width: 200px;
+        }
+        .modx-tv input[type="text"] {
+                line-height: 20px;
+                height: auto;
+        }    
+        .modx-tv input[type="text"] {
+                line-height: 20px;
+                height: auto;
+        }       
+        .modx-tv .x-superboxselect-input-field {
+                min-width: 200px;
+        }
+ }
 
   /* is outside of the label */
   .modx-tv-inherited {


### PR DESCRIPTION
If you are moving textfields and textareas to

modx-resource-main-left
or
modx-resource-main-right

they are slightly too wide on the right side, breaking the boundaries of their surrounding columns.

Width:99% combined with padding: 5px may result in containers bigger than 100%. We can use box-sizing: border-box to prevent this behaviour. 

Box-sizing is supported by 98% of all browsers: http://caniuse.com/#search=box-sizing Even if it is not supported, the form fields should still be usable.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13323
